### PR TITLE
feat: Configure project as a PWA

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -20,8 +20,24 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
+      "output": "single",
+      "favicon": "./assets/images/favicon.png",
+      "pwa": {
+        "name": "NABORI Corp",
+        "shortName": "NABORI",
+        "themeColor": "#ffffff",
+        "backgroundColor": "#ffffff",
+        "display": "standalone",
+        "scope": "/",
+        "startUrl": "/",
+        "icons": [
+          {
+            "src": "./assets/images/icon.png",
+            "sizes": "192x192",
+            "type": "image/png"
+          }
+        ]
+      }
     },
     "plugins": [
       "expo-router",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "export": "expo export -p web"
   },
   "dependencies": {
     "@expo/ngrok": "^4.1.3",


### PR DESCRIPTION
This change configures the Expo project to be a Progressive Web App (PWA) by adding the necessary PWA manifest properties to `app.json`.